### PR TITLE
fix: icon distortion during svg to font conversion

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -44,6 +44,8 @@ for (const set of sets) {
       css: false,
       html: true,
       startCodepoint: START_CODEPOINT,
+      fontHeight: 1000,
+      normalize: true,
     },
     (error: any) => {
       if (error) {


### PR DESCRIPTION
Hello, in my macbook with retina display I can see that the icons are a bit distorted, especially the search icon is not round, or the dots of the branch icon are not aligned.

This is due to a rounding error, so I increased the font height a normalized it.  
Here's an issue that talks about this: https://github.com/fontello/svg2ttf/issues/18

## Image Comparison

left is before  
right is after

![before-after](https://user-images.githubusercontent.com/13663338/110060378-1e18a580-7d66-11eb-876f-db23268dc2d3.jpg)

Another comparison, original size:

<img height="58" src="https://user-images.githubusercontent.com/13663338/110062644-f0356000-7d69-11eb-8990-777ea8002430.png" alt="before-after-2">

## Weight

Unfortunately this change slightly increases the package size, here's the comparison:

- Before: 15.09KB
- After: 16.49KB

> (size after running `vsce package`)

Maybe we can lower the `fontHeight` number to lower the size increase, I can test different numbers if you want.

## References

Config options for `webfonts-generator`: https://github.com/sunflowerdeath/webfonts-generator#fontname-normalize-fontheight-round-descent